### PR TITLE
Add 2nd assignment config (rhel.ron)

### DIFF
--- a/data/assignments-rhel.ron
+++ b/data/assignments-rhel.ron
@@ -1,0 +1,10 @@
+// WARNING: Modifications to this file will not be preserved on upgrade.
+// To configure, make new .ron files under /etc/system76-scheduler/assignments/.
+
+{
+// Absolute lowest priority
+(19, Idle): [
+    "dnf",
+    "rpm",
+    "yum",
+]}

--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ install:
         {{confdir}}/system76-scheduler/exceptions
     install -Dm0644 data/config.ron {{confdir}}/system76-scheduler/config.ron
     install -Dm0644 data/assignments.ron {{confdir}}/system76-scheduler/assignments/default.ron
+    install -Dm0644 data/assignments-rhel.ron {{confdir}}/system76-scheduler/assignments/rhel.ron
     install -Dm0644 data/exceptions.ron {{confdir}}/system76-scheduler/exceptions/default.ron
     install -Dm04755 target/{{target}}/{{binary}} {{target_bin}}
     install -Dm0644 data/{{id}}.service {{libdir}}/systemd/system/{{id}}.service

--- a/system76-scheduler.spec.rpkg
+++ b/system76-scheduler.spec.rpkg
@@ -49,6 +49,7 @@ just rootdir=%{buildroot} install
 %{_bindir}/system76-scheduler
 %{_sysconfdir}/system76-scheduler/config.ron
 %{_sysconfdir}/system76-scheduler/assignments/default.ron
+%{_sysconfdir}/system76-scheduler/assignments/rhel.ron
 %{_sysconfdir}/system76-scheduler/exceptions/default.ron
 %{_unitdir}/com.system76.Scheduler.service
 %{_sysconfdir}/dbus-1/system.d/com.system76.Scheduler.conf


### PR DESCRIPTION
Adds a 2nd default config (`rhel.ron`) which is meant to contain RHEL-specific configurations. In this case, we add `dnf`, `yum`, and `rpm` to the very low priority tier where `apt`, `apt-get`, and `dpkg` exist in the default pop-os config.